### PR TITLE
fix: enable SQLite foreign key enforcement

### DIFF
--- a/db.py
+++ b/db.py
@@ -37,6 +37,7 @@ def get_connection():
     """Open a connection to the database with row_factory set."""
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
     return conn
 
 


### PR DESCRIPTION
Closes #3

## What

Enable SQLite foreign key enforcement on every database connection.

## Why

`get_connection()` doesn't run any PRAGMA, so every connection in the app has FK enforcement off (SQLite defaults this off for backwards-compatibility). Any caller that inserts into `owned_cards` with a `card_id` not present in `cards` would silently succeed, creating a phantom ownership row. The `FOREIGN KEY` declarations in the schema are currently decorative.

## How

Added `conn.execute("PRAGMA foreign_keys = ON")` inside `get_connection()` so every connection gets it automatically. PRAGMA is per-connection in SQLite, not per-database, so it has to be set on every open. Putting it in the chokepoint function ensures no caller can forget.