### PR TITLE
docs: update add_owned_card docstring to match enforced behavior

### DIFF
--- a/db.py
+++ b/db.py
@@ -93,7 +93,9 @@ def add_card(card_id, name, set_name, number, rarity, market_price, price_update
     conn.close()
 
 def add_owned_card(card_id, quantity, purchase_price, condition, acquired_date):
-    """Add a new owned card record. Silently ignores if card_id doesn't exist in cards table."""
+    """Insert a new ownership row for an existing card. 
+    
+    Raises sqlite3.IntegrityError if card_id does not exist in the cards table"""
     conn = get_connection()
     cursor = conn.cursor()  
     cursor.execute(


### PR DESCRIPTION
Closes #4 

## What

Replace the `add_owned_card` docstring with one that describes the actual function behavior, including the `IntegrityError` raised on missing `card_id`.

## Why

The old docstring claimed silent ignore behavior that was never true, and now that PR #3 enabled FK enforcement, the function's actual behavior is to raise `IntegrityError`. 

## How

Update docstring of `add_owned_card`. No code change