### PR TITLE
feat: add migration system with quantity check constraint

### DIFF
--- a/db.py
+++ b/db.py
@@ -27,7 +27,8 @@ def init_db():
             purchase_price REAL,
             condition TEXT,
             acquired_date TEXT,
-            FOREIGN KEY (card_id) REFERENCES cards(id)
+            FOREIGN KEY (card_id) REFERENCES cards(id),
+            CHECK (quantity > 0)
         );
     """)
     conn.commit()
@@ -40,6 +41,25 @@ def get_connection():
     conn.execute("PRAGMA foreign_keys = ON")
     return conn
 
+def run_migrations():
+    """Run all migration scripts in the migrations/ directory and record which ones have been applied."""
+    conn = get_connection()
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE IF NOT EXISTS schema_migrations (name TEXT PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)")
+    cursor.execute("SELECT name FROM schema_migrations")
+    applied = set(row["name"] for row in cursor.fetchall())
+    migration_files = sorted(f for f in os.listdir("migrations") if f.endswith(".sql"))
+    # the migration files run BEGIN TRANSACTION and COMMIT themselves, so we don't wrap this loop in a transaction
+    for filename in migration_files:
+        if filename in applied:
+            continue
+        with open(os.path.join("migrations", filename), "r") as f:
+            sql = f.read()
+            print(f"Applying migration: {filename}")
+            cursor.executescript(sql)
+        cursor.execute("INSERT INTO schema_migrations (name) VALUES (?)", (filename,))
+    conn.commit()
+    conn.close()   
 
 def get_all_cards():
     """Return every card in the cards table."""

--- a/migrations/001_add_quantity_check.sql
+++ b/migrations/001_add_quantity_check.sql
@@ -1,0 +1,26 @@
+-- Disable FK enforcement during table rebuild.
+-- Re-enabled automatically by get_connection() on next connection.
+PRAGMA foreign_keys = OFF;
+
+BEGIN TRANSACTION;
+
+CREATE TABLE owned_cards_new (
+    id INTEGER PRIMARY KEY,
+    card_id TEXT NOT NULL,
+    quantity INTEGER NOT NULL DEFAULT 1,
+    purchase_price REAL,
+    condition TEXT,
+    acquired_date TEXT,
+    FOREIGN KEY (card_id) REFERENCES cards(id),
+    CHECK (quantity > 0)
+);
+
+INSERT INTO owned_cards_new (id, card_id, quantity, purchase_price, condition, acquired_date)
+SELECT id, card_id, quantity, purchase_price, condition, acquired_date FROM owned_cards;
+
+DROP TABLE owned_cards;
+
+ALTER TABLE owned_cards_new RENAME TO owned_cards;
+
+COMMIT;
+

--- a/web.py
+++ b/web.py
@@ -10,6 +10,7 @@ import api
 import collection
 
 db.init_db()
+db.run_migrations()
 
 EDIT_PASSWORD = os.environ.get("EDIT_PASSWORD", "")
 SESSION_SECRET = os.environ.get("SESSION_SECRET") or secrets.token_hex(32)


### PR DESCRIPTION
Closes #2

## What

Adds a database migration system and uses it to enforce `CHECK (quantity > 0)` on `owned_cards`.

## Why

Issue #2 identified that `owned_cards.quantity` had no schema-level guardrail. The column was `INTEGER NOT NULL DEFAULT 1` but nothing prevented a `0` or negative value from being stored. SQLite has no `ALTER TABLE ADD CONSTRAINT` for adding CHECKs to existing tables, so adding the constraint requires a table rebuild and doing that safely on a database with real data requires a migration system.

## How

- New `migrations/` directory holds versioned `.sql` files, applied in filename order.
- `run_migrations()` in `db.py` creates a `schema_migrations` tracking table on first run, queries which migrations have already been applied, and runs only the pending ones via `cursor.executescript()`.
- `run_migrations()` is called from `web.py` on app startup, right after `init_db()`.
- `migrations/001_add_quantity_check.sql` does the table rebuild: creates `owned_cards_new` with the CHECK constraint, copies all rows over, drops the old table, renames the new one. Wrapped in `BEGIN/COMMIT` for atomicity, with `PRAGMA foreign_keys = OFF` outside the transaction during the rebuild.
- `init_db()` updated so the CHECK constraint is in `CREATE TABLE owned_cards`. Fresh databases get the constraint via `init_db()`; existing databases get it via the migration. Both paths converge on the same final schema.

## Testing

Verified locally against both scenarios:

- **Fresh database**: deleted local DB, started app. `init_db()` created tables with constraint, `run_migrations()` applied 001, recorded 001 in `schema_migrations`.
- **Existing database**: restored a pre-migration DB (8 rows, old schema). After app startup, schema had the CHECK constraint, all 8 rows preserved (verified by row count and min/max/avg of `quantity`), `schema_migrations` had 001 recorded.
- **Idempotent restart**: subsequent app restarts don't re-run 001.
- **Constraint enforcement**: direct `INSERT` with `quantity = 0` raises `CHECK constraint failed`. Browser-level `min="1"` on the form input catches it before the request hits the server, so the constraint serves as defense-in-depth.

## Notes

The repo's existing production database on Fly is in the "pre-migration-system" state and will pick up the constraint on next deploy when the runner applies 001 against it. A pre-deploy data check (`SELECT COUNT(*) FROM owned_cards WHERE quantity <= 0`) confirmed zero rows would violate the new constraint, so the rebuild's `INSERT INTO ... SELECT` step will succeed.