### PR TITLE
Fix/upsert card prices and disclose Claude usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [Live Demo](https://pokemon-tcg-tracker.fly.dev/)
 
-A personal Pokémon Trading Card Game collection tracker with live pricing, statistics, and a search-driven acquisition flow. Built as a full-stack project to learn SQL, REST APIs, and modern web fundamentals.
+A personal Pokémon Trading Card Game collection tracker with live pricing, statistics, and a search-driven acquisition flow. Built as a full-stack project to learn SQL, REST APIs, and modern web fundamentals. 
+
+Used Claude as a pair-programmer and tutor. I made the architecture and implementation decisions; Claude helped me reason through tradeoffs, catch bugs, and turn my notes into clear issues and documentation.
 
 ## Features
 

--- a/db.py
+++ b/db.py
@@ -98,13 +98,16 @@ def get_last_price_update():
     return row["last_updated"]
 
 def add_card(conn, card_id, name, set_name, number, rarity, market_price, price_updated_at, image_url):
-    """Add a new card to the cards table. Silently ignores duplicates. Caller is responsible for committing the transaction."""
+    """Insert a new card or update an existing one's price. Caller is responsible for committing the transaction."""
     cursor = conn.cursor()
     cursor.execute(
         """
-        INSERT OR IGNORE INTO cards
+        INSERT INTO cards
         (id, name, set_name, number, rarity, market_price, price_updated_at, image_url)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (id) DO UPDATE SET
+            market_price = excluded.market_price,
+            price_updated_at = excluded.price_updated_at
         """,
         (card_id, name, set_name, number, rarity, market_price, price_updated_at, image_url)
     )


### PR DESCRIPTION
Closes #11

## What

Replace `INSERT OR IGNORE` in `add_card` with an `ON CONFLICT (id) DO UPDATE` clause to refresh `market_price` and `price_updated_at` when a card is re-acquired. Other metadata columns (`name`, `set_name`, `number`, `rarity`, `image_url`) are intentionally left unchanged on conflict.

Also includes a small docs-only commit adding a Claude usage disclosure to the README.

## Why

`acquire_card` calls `add_card`, which used `INSERT OR IGNORE`. When the card already exists in the cards table, the insert was silently skipped and the row's `market_price` and `price_updated_at` columns retained their old values until the next `refresh_all_prices` run.

Until PR #8 this was masked by a redundant `update_card_price` call that ran right after `add_card` and overwrote the price columns. PR #8 removed that call (it was duplicating work in the new-card case), which exposed the staleness on re-acquire as a small behavior gap.

## Notes

Issue #11 flagged that `update_card_price` might become redundant after this change. Keeping it: it has one caller (`refresh_all_prices`), and replacing it with `add_card` there would be misleading. It would require passing the full 8-argument signature when only 3 fields are relevant.
