### PR TITLE
fix: preserve aspect ratio on search card images

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -162,6 +162,7 @@ h2 {
 
 .search-result img {
   width: 100%;
+  height: auto; 
   border-radius: 4px;
 }
 


### PR DESCRIPTION
Closes #18

## What

Add `height: auto` to `.search-result img` so search card images scale proportionally with width instead of stretching to fill the grid column.

## Why

The `.search-result img` rule sets `width: 100%` but lacked a paired `height: auto`. The HTML `height="330"` attribute then locked the height while width compressed to fit the grid column, producing a horizontally squished image. The analogous `.card img` rule already pairs both correctly. This PR brings `.search-result img` in line with that pattern.

## Notes

The duplicate styling between `.card img` and `.search-result img` is a small drift risk. Worth a follow-up to consolidate into a shared rule, but out of scope here.