### PR TITLE
Add pytest test suite for db layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.6.3
 uvicorn==0.46.0
+pytest==8.3.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+import db
+
+@pytest.fixture
+def fresh_db(tmp_path):
+    db.DB_PATH = str(tmp_path / "test.db")
+    db.init_db()
+    yield db.DB_PATH

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,124 @@
+import db
+import pytest
+import sqlite3
+
+def test_add_card_round_trip(fresh_db):
+    conn = db.get_connection()
+    db.add_card(
+        conn,
+        card_id="base1-4",
+        name="Charizard",
+        set_name="Base Set",
+        number="4",
+        rarity="Holo Rare",
+        market_price=350.00,
+        price_updated_at="2026-05-07T00:00:00Z",
+        image_url="https://example.com/charizard.png",
+    )
+    conn.commit()
+    conn.close()
+
+    row = db.get_card_by_id("base1-4")
+
+    assert row is not None
+    assert row["name"] == "Charizard"
+    assert row["market_price"] == 350.00
+
+def test_total_collection_value_multiplies_price_by_quantity(fresh_db):
+    conn = db.get_connection()
+    db.add_card(
+        conn,
+        card_id="base1-4",
+        name="Charizard",
+        set_name="Base Set",
+        number="4",
+        rarity="Holo Rare",
+        market_price=350.00,
+        price_updated_at="2026-05-07T00:00:00Z",
+        image_url="https://example.com/charizard.png",
+    )
+    db.add_card(
+        conn,
+        card_id="base1-5",
+        name="Blastoise",
+        set_name="Base Set",
+        number="5",
+        rarity="Holo Rare",
+        market_price=200.00,
+        price_updated_at="2026-05-07T00:00:00Z",
+        image_url="https://example.com/blastoise.png",
+    )
+    db.add_owned_card(
+        conn,
+        card_id="base1-4",
+        quantity=2,
+        purchase_price=300.00,
+        condition="Near Mint",
+        acquired_date="2026-05-01",
+    )
+    db.add_owned_card(
+        conn,
+        card_id="base1-5",
+        quantity=3,
+        purchase_price=150.00,  
+        condition="Lightly Played",
+        acquired_date="2026-05-02",
+    )
+    conn.commit()
+    conn.close()
+
+    total_value = db.get_total_collection_value()
+    expected_value = (350.00 * 2) + (200.00 * 3)  # $700 + $600 = $1300
+    assert total_value == pytest.approx(expected_value)
+
+def test_add_card_upsert(fresh_db):
+    conn = db.get_connection()
+    db.add_card(
+        conn,
+        card_id="base1-4",
+        name="Charizard",
+        set_name="Base Set",
+        number="4",
+        rarity="Holo Rare",
+        market_price=350.00,
+        price_updated_at="2026-05-03",
+        image_url="https://example.com/charizard.png",
+    )
+    conn.commit()
+
+    # Update the same card with new price
+    db.add_card(
+        conn,
+        card_id="base1-4",
+        name="Charizard",
+        set_name="Base Set",
+        number="4",
+        rarity="Holo Rare",
+        market_price=400.00,  # Updated price
+        price_updated_at="2026-05-07",
+        image_url="https://example.com/charizard.png",
+    )
+    conn.commit()
+    conn.close()
+
+    row = db.get_card_by_id("base1-4")
+    assert row is not None
+    assert row["market_price"] == pytest.approx(400.00)  # Price should be updated
+
+    conn = db.get_connection()
+    count = conn.execute("SELECT COUNT(*) FROM cards WHERE id = ?", ("base1-4",)).fetchone()[0]
+    conn.close()
+    assert count == 1
+
+def test_fk_violation_on_owned_cards(fresh_db):
+    conn = db.get_connection()
+    with pytest.raises(sqlite3.IntegrityError):
+        db.add_owned_card(
+            conn,
+            card_id="nonexistent-card",
+            quantity=1,
+            purchase_price=100.00,
+            condition="Near Mint",
+            acquired_date="2026-05-01",
+        )
+    conn.close()


### PR DESCRIPTION
## What

Adds a pytest test suite covering the database layer.

## Why

Establishes a regression safety net before adding CI (#10) and any further refactors. Closes #9.

## Coverage

- Round-trip insert/read for `add_card` + `get_card_by_id`
- `get_total_collection_value` correctly multiplies price × quantity across a JOIN
- `add_card` upsert behavior: same `card_id` updates price without creating a duplicate row
- FK constraint enforcement: `add_owned_card` raises `IntegrityError` for nonexistent `card_id`

## Test infrastructure
- `pyproject.toml` configures pytest's `pythonpath` and `testpaths`
- `tests/conftest.py` provides a `fresh_db` fixture using `tmp_path` for full test isolation
- Each test gets a fresh SQLite file; no shared state, no cleanup needed

## How to run
```bash
pip install -r requirements.txt
pytest
```