### PR TITLE
Add GitHub Actions workflow to run pytest on push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that runs the pytest suite on every push to main and every pull request targeting main.

## Why

The test suite from #9 only catches regressions if it actually runs. CI enforces this automatically — broken tests block PR merges, and main is verified green after every merge. Catches issues before Fly auto-deploys, not after.

## Configuration
- Triggers: push to main, pull_request targeting main
- Runner: ubuntu-latest
- Python: 3.11 (matches local dev and Fly runtime)
- Steps: checkout → setup Python → install requirements → pytest

Closes #10.