### PR TITLE
fix: reset acquire modal form fields on open

### DIFF
--- a/static/edit-collection.js
+++ b/static/edit-collection.js
@@ -13,6 +13,7 @@ export function openAcquireModal(card) {
       <div class="preview-set">${card.set.name} · #${card.number}</div>
     </div>
   `;
+  document.getElementById("acquire-form").reset();
   document.getElementById("form-date").value = new Date().toISOString().slice(0, 10);
   document.getElementById("modal-overlay").classList.add("open");
 }


### PR DESCRIPTION
Acquire modal retained values (purchase price, condition, quantity) from the previous open — only form-date was being reset. Calls form.reset() on #acquire-form at the top of openAcquireModal, then overrides form-date to today afterward.

form.reset() over manual field clearing so new fields added to the HTML with a value="..." default Just Work without touching openAcquireModal.

Verified by manual walkthrough: open modal, dirty fields, close, reopen on a different card — fields clean, date is today.