### PR TITLE
refactor: consolidate schema definition into initial migration

### DIFF
--- a/db.py
+++ b/db.py
@@ -3,37 +3,6 @@ import os
 
 DB_PATH = os.environ.get("DB_PATH", "collection.db")
 
-def init_db():
-    """Create tables if they don't exist. Safe to run on every startup."""
-    conn = get_connection()
-    cursor = conn.cursor()
-    cursor.execute("""
-        CREATE TABLE IF NOT EXISTS cards (
-            id TEXT PRIMARY KEY,
-            name TEXT NOT NULL,
-            set_name TEXT,
-            number TEXT,
-            rarity TEXT,
-            market_price REAL,
-            price_updated_at TEXT,
-            image_url TEXT
-        );
-    """)
-    cursor.execute("""
-        CREATE TABLE IF NOT EXISTS owned_cards (
-            id INTEGER PRIMARY KEY,
-            card_id TEXT NOT NULL,
-            quantity INTEGER NOT NULL DEFAULT 1,
-            purchase_price REAL,
-            condition TEXT,
-            acquired_date TEXT,
-            FOREIGN KEY (card_id) REFERENCES cards(id),
-            CHECK (quantity > 0)
-        );
-    """)
-    conn.commit()
-    conn.close()
-
 def get_connection():
     """Open a connection to the database with row_factory set."""
     conn = sqlite3.connect(DB_PATH)

--- a/migrations/000_initial_schema.sql
+++ b/migrations/000_initial_schema.sql
@@ -1,0 +1,26 @@
+-- Initial schema, extracted from db.init_db(). Uses IF NOT EXISTS so existing production DBs no-op cleanly.
+BEGIN TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS cards (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    set_name TEXT,
+    number TEXT,
+    rarity TEXT,
+    market_price REAL,
+    price_updated_at TEXT,
+    image_url TEXT
+);
+
+
+CREATE TABLE IF NOT EXISTS owned_cards (
+    id INTEGER PRIMARY KEY,
+    card_id TEXT NOT NULL,
+    quantity INTEGER NOT NULL DEFAULT 1,
+    purchase_price REAL,
+    condition TEXT,
+    acquired_date TEXT,
+    FOREIGN KEY (card_id) REFERENCES cards(id)
+);
+
+COMMIT;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import db
 @pytest.fixture
 def fresh_db(tmp_path):
     db.DB_PATH = str(tmp_path / "test.db")
-    db.init_db()
     db.run_migrations()
     yield db.DB_PATH
 

--- a/web.py
+++ b/web.py
@@ -14,7 +14,6 @@ import collection
 
 load_dotenv()
 
-db.init_db()
 db.run_migrations()
 
 COOKIE_SECURE = os.environ.get("COOKIE_SECURE", "false").lower() == "true"


### PR DESCRIPTION
init_db() duplicated migration state and had silently drifted from the
canonical schema (the quantity CHECK constraint leaked from migration 001
into init_db()'s table definition).

Extract the original pre-migration schema into migrations/000_initial_schema.sql
with IF NOT EXISTS so existing production DBs no-op cleanly. Delete init_db().
Update web.py startup and tests/conftest.py to call run_migrations() only.

Verified by manual walkthrough: deleted local DB, started server, confirmed
schema_migrations populated 000/001/002 in order and tables have correct
final shape. Simulated prod path by deleting 000 from schema_migrations on
a populated DB, restarted, confirmed 000 re-applied as a no-op via IF NOT EXISTS.

Closes #31