### PR TITLE
feat: add password visibility toggle to login and register modals

### DIFF
--- a/static/auth.js
+++ b/static/auth.js
@@ -167,6 +167,15 @@ export function handleAuthModalToggle() {
   setAuthModalMode(newMode);
 }
 
+export function handlePasswordToggle(inputId, buttonId) {
+  const input = document.getElementById(inputId);
+  const button = document.getElementById(buttonId);
+  const type = input.type === "password" ? "text" : "password";
+  input.type = type;
+  button.ariaLabel = type === "password" ? "Show password" : "Hide password";
+  button.classList.toggle("is-visible");
+}
+
 export async function handleLogoutClick() {
   try {
     await fetch("/auth/logout", { method: "POST" });

--- a/static/index.html
+++ b/static/index.html
@@ -159,7 +159,21 @@
         </label>
         <label>
           Password
-          <input type="password" id="login-password" autocomplete="current-password" required>
+          <div class="password-input-field">
+            <input type="password" id="login-password" autocomplete="current-password" required>
+            <button type="button" id="login-show-password" class="password-toggle" aria-label="Show password">
+              <svg class="icon-eye" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/>
+                <circle cx="12" cy="12" r="3"/>     
+              </svg>
+              <svg class="icon-eye-off" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/>
+                <path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/>
+                <path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/>
+                <line x1="2" x2="22" y1="2" y2="22"/>  
+              </svg>
+            </button>
+          </div>
         </label>
         <button type="submit" id="login-submit">Log in</button>
       </form>
@@ -175,7 +189,21 @@
         </label>
         <label>
           Password
-          <input type="password" id="register-password" autocomplete="new-password" required>
+          <div class="password-input-field">
+            <input type="password" id="register-password" autocomplete="new-password" required>
+            <button type="button" id="register-show-password" class="password-toggle" aria-label="Show password">
+              <svg class="icon-eye" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/>
+                <circle cx="12" cy="12" r="3"/>     
+              </svg>
+              <svg class="icon-eye-off" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/>
+                <path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/>
+                <path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/>
+                <line x1="2" x2="22" y1="2" y2="22"/>  
+              </svg>
+            </button>
+          </div>
         </label>
         <button type="submit" id="register-submit">Register</button>
       </form>

--- a/static/main.js
+++ b/static/main.js
@@ -8,6 +8,7 @@ import {
   handleLogoutClick,
   handleRegisterSubmit,
   handleAuthModalToggle,
+  handlePasswordToggle,
 } from "/static/auth.js";
 import { refreshAll, refreshPrices, renderLoadError } from "/static/data-loaders.js";
 import {
@@ -68,6 +69,14 @@ document.getElementById("login-overlay").addEventListener("click", (e) => {
 });
 
 document.getElementById("login-form").addEventListener("submit", handleLoginSubmit);
+
+document.getElementById("login-show-password").addEventListener("click", () => {
+  handlePasswordToggle("login-password", "login-show-password");
+});
+
+document.getElementById("register-show-password").addEventListener("click", () => {
+  handlePasswordToggle("register-password", "register-show-password");
+});
 
 document.getElementById("logout-button").addEventListener("click", handleLogoutClick);
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -1140,6 +1140,37 @@ body.authed .auth-only-loggedout { display: none !important; }
   cursor: wait;
 }
 
+.password-input-field {
+  position: relative;
+  margin-top: 6px
+}
+
+#login-panel .password-input-field input {
+  padding-right: 48px;
+  margin-top: 0;
+}
+
+.password-toggle {
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  color: #94a3b8;
+  cursor: pointer;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.password-toggle .icon-eye-off { display: none; }
+.password-toggle.is-visible .icon-eye { display: none; }
+.password-toggle.is-visible .icon-eye-off { display: block; }
+
 /* --- Mobile responsiveness --- */
 @media (max-width: 600px) {
   body {


### PR DESCRIPTION
Closes #37 

Users had no way of verifying what they're typing into the password field of the login and register modals. Adds a svg icon to the end of the password form that toggles the type from `type="password"` to `type="text"`. Also updates the svg icon