### PR TITLE
fix: show one tile per unique card in owned-cards grid (#44)

### DIFF
--- a/db.py
+++ b/db.py
@@ -4,6 +4,7 @@ from contextlib import closing
 
 DB_PATH = os.environ.get("DB_PATH", "collection.db")
 
+# DUPLICATED in data-loaders.js — update both
 CONDITION_VALUE_PERCENTS = {
     "Near Mint": 1.0,
     "Lightly Played": 0.85,

--- a/static/data-loaders.js
+++ b/static/data-loaders.js
@@ -1,5 +1,20 @@
 import { apiFetch } from "/static/auth.js";
 
+// DUPLICATED in db.py — update both
+const CONDITION_VALUE_PERCENTS = {
+    "Near Mint": 1.0,
+    "Lightly Played": 0.85,
+    "Moderately Played": 0.65,
+    "Heavily Played": 0.45,
+    "Damaged": 0.25,
+}
+
+export function adjustedValue(row) {
+  if (row.market_price === null) return 0;
+  const conditionPercent = CONDITION_VALUE_PERCENTS[row.condition] || 1.0;
+  return row.market_price * row.quantity * conditionPercent;
+}
+
 export function refreshAll() {
   loadStats();
   loadBySet();
@@ -169,16 +184,33 @@ async function loadCards() {
   setEmptyStateVisible(isEmpty);
   if (isEmpty) return;
 
-  for (const card of cards) {
+  const groups = {};
+  for (const row of cards) {
+    if (!groups[row.card_id]) {
+      groups[row.card_id] = {
+        card_id:        row.card_id,
+        name:           row.name,
+        set_name:       row.set_name,
+        image_url:      row.image_url,
+        total_quantity: 0,
+        total_value:    0,
+      };
+    }
+    groups[row.card_id].total_quantity += row.quantity;
+    groups[row.card_id].total_value    += adjustedValue(row);
+  }
+  const grouped = Object.values(groups);
+
+  for (const card of grouped) {
     const div = document.createElement("div");
     div.className = "card";
-    div.dataset.ownedId = card.owned_id;
     div.dataset.cardId = card.card_id;
     div.innerHTML = `
       <img src="${card.image_url}" alt="" width="240" height="330" loading="lazy" decoding="async">
       <div class="card-name">${card.name}</div>
       <div class="card-set">${card.set_name}</div>
-      <div class="card-price">$${(card.market_price ?? 0).toFixed(2)}</div>
+      <div class="card-price">$${(card.total_value).toFixed(2)}</div>
+      <div class="card-quantity">× ${card.total_quantity}</div>
     `;
     container.appendChild(div);
   }

--- a/static/edit-collection.js
+++ b/static/edit-collection.js
@@ -1,5 +1,5 @@
 import { apiFetch } from "/static/auth.js";
-import { refreshAll } from "/static/data-loaders.js";
+import { refreshAll, adjustedValue } from "/static/data-loaders.js";
 
 let currentDetailCardId = null;
 let currentAcquireCard = null;
@@ -51,6 +51,10 @@ export async function openDetail(cardId) {
       `You own ${ownership.length} ${ownership.length === 1 ? "copy" : "copies"} of this card:`;
 
     for (const row of ownership) {
+      const nowValue = card.market_price !== null
+        ? adjustedValue({ market_price: card.market_price, quantity: row.quantity, condition: row.condition })
+        : null;
+
       const div = document.createElement("div");
       div.className = "ownership-row";
       div.innerHTML = `
@@ -58,7 +62,10 @@ export async function openDetail(cardId) {
           <div class="condition">${row.condition} × ${row.quantity}</div>
           <div class="meta">Acquired ${row.acquired_date || "unknown date"}</div>
         </div>
-        <div class="price">${row.purchase_price !== null ? `$${row.purchase_price.toFixed(2)}` : "—"}</div>
+        <div class="price">
+          Paid ${row.purchase_price !== null ? `$${row.purchase_price.toFixed(2)}` : "—"}
+          · Now ${nowValue !== null ? `$${nowValue.toFixed(2)}` : "—"}
+        </div>
         <div class="actions auth-required">
           <button class="icon-btn" data-owned-id="${row.id}" data-action="edit">Edit</button>
           <button class="icon-btn danger" data-owned-id="${row.id}" data-action="delete">Delete</button>

--- a/static/styles.css
+++ b/static/styles.css
@@ -142,6 +142,12 @@ h2 {
   font-size: 16px;
 }
 
+.card-quantity {
+  font-size: 12px;
+  color: #94a3b8;
+  margin-top: 2px;
+}
+
 /* --- Search results grid --- */
 #search-results {
   display: grid;


### PR DESCRIPTION
Closes #44.

The owned-cards grid was rendering one tile per `owned_cards` row, so a
user with multiple copies of the same card saw duplicate tiles, each
showing the unadjusted NM market price.

Grid: group `/collection` rows by `card_id` in `loadCards`, render one
tile per unique card with a quantity badge and a summed
condition-adjusted value across all copies.

Modal: add a "Now" value next to "Paid" on each ownership row, computed
as `market_price * quantity * condition_multiplier`. The
`/cards/:id/ownership` endpoint doesn't return `market_price` per row,
so "Now" is computed from `card.market_price` fetched alongside the
ownership list.

Adds `CONDITION_VALUE_PERCENTS` and `adjustedValue()` to
`data-loaders.js`, duplicating the table from `db.py`. Both sides have
a comment pointing at the other.

Verified: grid tile, modal per-row "Now" values, and Total Value stat
all sum to the same number.