### PR TITLE
Feat/filter cache

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,3 +1,4 @@
+import json
 import sqlite3
 import os
 from contextlib import closing
@@ -255,3 +256,31 @@ def create_user(username: str, email: str, hashed_password: str) -> int:
             "INSERT INTO users (username, email, hashed_password) VALUES (?, ?, ?)",
             (username, email, hashed_password),
         ).lastrowid
+
+# filter cache
+
+def get_filter_cache(key:str) -> list | None:
+    """Return the cached value for the given filter key, or None if not cached."""
+    with closing(get_connection()) as conn:
+        row = conn.execute(
+            "SELECT value FROM filter_cache WHERE key = ?",
+            (key,),
+        ).fetchone()
+        if row is None:
+            return None
+        return json.loads(row["value"])
+
+
+def set_filter_cache(key: str, value: list) -> None:
+    """Cache or update the filter value for the given key. Bumps updated_at on write."""
+    with closing(get_connection()) as conn, conn:
+        conn.execute(
+            """
+            INSERT INTO filter_cache (key, value)
+            VALUES (?, ?)
+            ON CONFLICT (key) DO UPDATE SET
+                value = excluded.value,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (key, json.dumps(value)),
+        )

--- a/migrations/003_filter_cache.sql
+++ b/migrations/003_filter_cache.sql
@@ -1,0 +1,11 @@
+-- Local cache for /api/filters/* dropdown data from pokemontcg.io.
+-- Refreshed manually via scripts/refresh_filter_cache.py; not auto-refreshed.
+BEGIN TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS filter_cache (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMIT;

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ dnspython==2.8.0
 email-validator==2.3.0
 fastapi==0.136.1
 h11==0.16.0
+httpcore==1.0.9
+httpx==0.28.1
 idna==3.13
 iniconfig==2.3.0
 itsdangerous==2.2.0

--- a/scripts/refresh_filter_cache.py
+++ b/scripts/refresh_filter_cache.py
@@ -1,0 +1,30 @@
+"""Refresh the cached filter dropdown data from pokemontcg.io.
+
+Usage:
+    python -m scripts.refresh_filter_cache
+"""
+from api import (
+    get_sets,
+    get_rarities,
+    get_subtypes,
+    get_supertypes,
+    get_types,
+)
+import db
+
+FILTERS = {
+    "sets": get_sets,
+    "types": get_types,
+    "subtypes": get_subtypes,
+    "supertypes": get_supertypes,
+    "rarities": get_rarities,
+}
+
+def main():
+    for key, fetch_fn in FILTERS.items():
+        value = fetch_fn()
+        db.set_filter_cache(key, value)
+        print(f"Cached {len(value)} {key}")
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 import db
+import os
+os.environ.setdefault("JWT_SECRET", "test-secret-not-for-prod")
 
 @pytest.fixture
 def fresh_db(tmp_path):

--- a/tests/test_filter_cache.py
+++ b/tests/test_filter_cache.py
@@ -1,0 +1,21 @@
+import db
+import pytest
+
+def test_get_filter_cache_returns_none_when_key_missing(fresh_db):
+    assert db.get_filter_cache("nonexistent_key") is None
+
+def test_filter_cache_round_trip(fresh_db):
+    key = "test_key"
+    value = [{"id": "a", "name": "foo", "set": "a"}]
+    db.set_filter_cache(key, value)
+    cached_value = db.get_filter_cache(key)
+    assert cached_value == value
+
+def test_set_filter_cache_updates_existing_row(fresh_db):
+    key = "test_key"
+    initial_value = [{"id": "a", "name": "foo", "set": "a"}]
+    updated_value = [{"id": "b", "name": "foo", "set": "b"}]
+    db.set_filter_cache(key, initial_value) 
+    db.set_filter_cache(key, updated_value)
+    cached_value = db.get_filter_cache(key)
+    assert cached_value == updated_value    

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+import db
+from web import app
+
+client = TestClient(app)
+
+def test_filter_sets_endpoint_returns_cached_data(fresh_db):
+    db.set_filter_cache("sets", [{"id": "test1", "name": "Test Set"}])
+    
+    response = client.get("/api/filters/sets")
+    
+    assert response.status_code == 200
+    assert response.json() == [{"id": "test1", "name": "Test Set"}]
+
+def test_filter_endpoint_returns_empty_when_cache_missing(fresh_db):
+    response = client.get("/api/filters/sets")
+    assert response.status_code == 200
+    assert response.json() == []

--- a/web.py
+++ b/web.py
@@ -190,27 +190,35 @@ def delete_owned(owned_id: int, user_id: int = Depends(auth.get_current_user)):
         return {"status": "ok", "cascade_deleted_card": True}
     return {"status": "ok", "cascade_deleted_card": False}
 
+def get_filter_or_warn(key: str) -> list:
+    """Read a filter from the cache; warn and return [] if missing."""
+    cached = db.get_filter_cache(key)
+    if cached is None:
+        print(f"WARN: filter_cache empty for key={key}")
+        return []
+    return cached
+
 @app.get("/api/filters/sets")
 def filter_sets():
-    return api.get_sets()
+    return get_filter_or_warn("sets")
 
 
 @app.get("/api/filters/types")
 def filter_types():
-    return api.get_types()
+    return get_filter_or_warn("types")
 
 
 @app.get("/api/filters/subtypes")
 def filter_subtypes():
-    return api.get_subtypes()
+    return get_filter_or_warn("subtypes")
 
 @app.get("/api/filters/supertypes")
 def filter_supertypes():
-    return api.get_supertypes()
+    return get_filter_or_warn("supertypes")
 
 @app.get("/api/filters/rarities")
 def filter_rarities():
-    return api.get_rarities()
+    return get_filter_or_warn("rarities")
 
 @app.get("/stats/last-updated")
 def last_updated():


### PR DESCRIPTION
Closes #46.

The /api/filters/{sets,rarities,types,supertypes,subtypes} endpoints were
calling api.* helpers that proxied to pokemontcg.io on every request. In
prod this consistently 500'd after Fly's ~60s edge timeout, leaving the
search dropdowns empty and throwing a JSON.parse SyntaxError on the
frontend when it tried to parse the 500 page.

Backend: new filter_cache table (migration 003), keyed by filter type with
the API response stored as a JSON blob. db.get_filter_cache /
db.set_filter_cache handle serialization; set uses UPSERT with an explicit
updated_at bump. The /api/filters/* endpoints now read from the cache via
a small get_filter_or_warn helper, returning [] and printing a warning
when the key is missing.

Refresh: scripts/refresh_filter_cache.py iterates the five filter types,
calls the existing api.* helpers, and writes the results to the cache.
Manual via `python -m scripts.refresh_filter_cache`; fail-fast on upstream
errors, safe to re-run. pokemontcg.io is no longer in the user request
path.

Tests: 3 unit tests for the data layer (empty key, round-trip, UPSERT
update) and 2 endpoint tests covering cache-hit and cache-empty. Added
httpx + httpcore to requirements.txt for fastapi.testclient.

Bootstrap after deploy: `fly ssh console` then run the refresh script.

Verified: all 5 endpoints return 200 with cached data, response times drop
from 60s timeouts to ~7ms locally, dropdowns populate on page load.